### PR TITLE
Disable k8s probes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,9 +114,7 @@ build-docker-bot:
 
 publish-docker-bot:
   stage:                           build
-  # uncomment after debug
-  # <<:                              *publish-deploy-stg-refs
-  <<: *common-refs
+  <<:                              *publish-deploy-stg-refs
   <<:                              *kubernetes-env
   <<:                              *build-push-docker-image
   variables:
@@ -145,9 +143,7 @@ deploy-stg:
   stage:                           staging
   <<:                              *deploy-k8s
   <<:                              *kubernetes-env
-  # uncomment after debug
-  # <<:                              *publish-deploy-stg-refs
-  <<: *common-refs
+  <<:                              *publish-deploy-stg-refs
   variables:
     CI_IMAGE:                      "paritytech/kubetools:3.5.3"
     ENVIRONMENT:                   parity-stg

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -30,6 +30,7 @@ common:
       kubernetes.io/ingress.class: traefik-internal
       traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
       traefik.ingress.kubernetes.io/router.tls: "true"
+  # Enable after endpoint is created
   # livenessProbe:
   #   httpGet:
   #     path: /health


### PR DESCRIPTION
The PR disables liveness and readiness probes because they are not currently implemented