### PR TITLE
Fix missing chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: matrix-admin-bot
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.16.0"
 dependencies:
 - name: gcloud-sqlproxy
   version: "0.22.6"
   repository: "https://charts.rimusz.net"
 - name: common
-  version: "0.2.1"
+  version: "0.2.2"
   repository: "https://paritytech.github.io/helm-charts/"


### PR DESCRIPTION
The chart was missing in the chart public repo, hence the deployment fails. I bumped the version which should fix the issue. 