### PR TITLE
[ci] Add ability to redeploy app on the same commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ variables:
   CI_IMAGE:                        node:16.10-alpine
   DOCKERHUB_REPO:                  "paritytech"
   IMAGE_NAME:                      docker.io/$DOCKERHUB_REPO/matrix-admin-bot
-  DOCKER_TAG:                      "${CI_COMMIT_SHORT_SHA}"
+  DOCKER_TAG:                      "${CI_COMMIT_SHORT_SHA}-$(date +%s)"
   VAULT_ADDR:                      "https://vault.parity-mgmt-vault.parity.io"
   VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
   VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
@@ -28,30 +28,23 @@ variables:
 
 .common-refs:                      &common-refs
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
 .test-refs:                        &test-refs
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs and from web interface
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-
-# Deploy on production goes only on tag
-.deploy-prod-refs:                 &deploy-prod-refs
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # on tags (i.e. v1.0, v2.1rc1) and from web interface
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # on tags (i.e. v1.0, v2.1rc1)
 
 # Publish docker image and deploy it on staging
 .publish-deploy-stg-refs:          &publish-deploy-stg-refs
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME == "master"                           # on commits to main branch and from web interface
     - if: $CI_COMMIT_REF_NAME == "master"                           # on commits to main branch
+
+# Deploy on production goes manually
+.deploy-prod-refs:                 &deploy-prod-refs
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master"                           # on commits to main branch manually
+      when: manual
 
 .kubernetes-env:                   &kubernetes-env
   image:                           $CI_IMAGE


### PR DESCRIPTION
The PR changes deploy logic:
 - Push to master will deploy on staging automatically and deploy on prod will have a button for manual deploy. 
 - Image now has a tag `<short_sha>-<unix timestamp>` so rerun the ci allows redeploy the app
 - Removed the rule with `web` because all rules works perfectly without it (even if I trigger them from web)