### PR TITLE
ci: Add CI job to publish docker image description to hub.docker.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,23 @@ publish-docker-bot:
   variables:
     DOCKERFILE:                    "Dockerfile"
 
+push-docker-image-description:
+  stage:                           build
+  <<:                              *kubernetes-env
+  variables:
+    CI_IMAGE:                      paritytech/dockerhub-description
+    DOCKERHUB_REPOSITORY:          $DOCKERHUB_REPO/$KUBE_NAMESPACE
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
+    SHORT_DESCRIPTION:             "Bot to keep the matrix channels maintainable and bulk invite new users to the channels"
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      changes:
+      - Dockerfile.README.md
+  script:
+    - cd / && sh entrypoint.sh
+
 #### stage:                        deploy
 
 .deploy:                           &deploy-k8s

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -1,0 +1,3 @@
+# matrix-admin-bot
+
+## [GitHub](https://github.com/paritytech/matrix-admin-bot)


### PR DESCRIPTION
Added CI job to publish Docker image description to [hub.docker.com](https://hub.docker.com/r/paritytech/matrix-admin-bot)
Description can be updated in a `Dockerfile.README.md` file in a repository root and as soon it will be merged into the `master` branch, its content will get published to [hub.docker.com](https://hub.docker.com/r/paritytech/matrix-admin-bot)

Related https://github.com/paritytech/ci_cd/issues/741