### PR TITLE
Fix GitLab environments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,6 +166,8 @@ deploy-stg:
   variables:
     CI_IMAGE:                      "paritytech/kubetools:3.5.3"
     ENVIRONMENT:                   parity-stg
+  environment:
+    name:                          parity-stg
   tags:
     - matrix-admin-bot-stg
 
@@ -177,5 +179,7 @@ deploy-prod:
   variables:
     CI_IMAGE:                      "paritytech/kubetools:3.5.3"
     ENVIRONMENT:                   parity-prod
+  environment:
+    name:                          parity-prod
   tags:
     - matrix-admin-bot-prod


### PR DESCRIPTION
Looks like [this commit](https://github.com/paritytech/matrix-admin-bot/commit/e8c9025e540beb9057aa1af9dc9d5f2ec92b59a5) accidentally removed the GitLab's deployment <-> environment binding. This PR restores that.