### PR TITLE
disabling ingress

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,7 +24,7 @@ common:
       port: 80
       targetPort: 8000
   ingress:
-    enabled: true
+    enabled: false
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-dns01
       kubernetes.io/ingress.class: traefik-internal


### PR DESCRIPTION
as discussed with @vas3k , it seems we have nothing to do with this exposed endpoint and it can be removed to avoid having an unnecessary exposed endpoint in the infra.